### PR TITLE
[LOCUS-33] Misbehaviour of search submitted when another search was being processed

### DIFF
--- a/common/searcherUtils.py
+++ b/common/searcherUtils.py
@@ -58,3 +58,7 @@ def send_to_websocket(channel_layer, where, method, message):
 
 def is_worker(sender):
     return sender in WORKER_NAMES
+
+
+def search_cancelled(search_id):
+    return not SearchParameters.objects.filter(pk=search_id).exists()

--- a/common/statusUpdate.py
+++ b/common/statusUpdate.py
@@ -1,7 +1,7 @@
 from django.db.models import F
 
 from common.searcherUtils import DB_FTSEARCHER_NAME, DB_URL_SEARCHER_NAME, TWITTER_URL_SEARCHER_NAME, \
-    TWITTER_TEXT_SEARCHER_NAME, GOOGLE_SEARCHER_NAME, INTERNET_SEARCH_MANAGER_NAME
+    TWITTER_TEXT_SEARCHER_NAME, GOOGLE_SEARCHER_NAME, INTERNET_SEARCH_MANAGER_NAME, search_cancelled
 from search.models import CrawlerStatus
 
 
@@ -9,20 +9,24 @@ class StatusUpdater:
     def __init__(self, crawler_name):
         self.crawler = crawler_name
 
-    def queued(self):
-        CrawlerStatus.objects.filter(pk=self.crawler).update(queued=F('queued') + 1)
+    def queued(self, search_id):
+        if not search_cancelled(search_id):
+            CrawlerStatus.objects.filter(pk=self.crawler).update(queued=F('queued') + 1)
 
-    def in_progress(self):
-        CrawlerStatus.objects.filter(pk=self.crawler).update(in_progress=F('in_progress') + 1)
-        CrawlerStatus.objects.filter(pk=self.crawler).update(queued=F('queued') - 1)
+    def in_progress(self, search_id):
+        if not search_cancelled(search_id):
+            CrawlerStatus.objects.filter(pk=self.crawler).update(in_progress=F('in_progress') + 1)
+            CrawlerStatus.objects.filter(pk=self.crawler).update(queued=F('queued') - 1)
 
-    def success(self):
-        CrawlerStatus.objects.filter(pk=self.crawler).update(in_progress=F('in_progress') - 1)
-        CrawlerStatus.objects.filter(pk=self.crawler).update(success=F('success') + 1)
+    def success(self, search_id):
+        if not search_cancelled(search_id):
+            CrawlerStatus.objects.filter(pk=self.crawler).update(in_progress=F('in_progress') - 1)
+            CrawlerStatus.objects.filter(pk=self.crawler).update(success=F('success') + 1)
 
-    def failure(self):
-        CrawlerStatus.objects.filter(pk=self.crawler).update(in_progress=F('in_progress') - 1)
-        CrawlerStatus.objects.filter(pk=self.crawler).update(failure=F('failure') + 1)
+    def failure(self, search_id):
+        if not search_cancelled(search_id):
+            CrawlerStatus.objects.filter(pk=self.crawler).update(in_progress=F('in_progress') - 1)
+            CrawlerStatus.objects.filter(pk=self.crawler).update(failure=F('failure') + 1)
 
 
 twitter_updater = StatusUpdater('twitter')

--- a/database/dbSearcher.py
+++ b/database/dbSearcher.py
@@ -1,15 +1,17 @@
 import asyncio
 import logging
 import string
+import traceback
 
 import numpy as np
 from channels.consumer import SyncConsumer
 from django.contrib.postgres.search import SearchQuery, SearchVector, SearchRank
+from django.db import transaction
 from sklearn.feature_extraction.text import TfidfVectorizer, CountVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
 from common.searcherUtils import get_main_search, send_to_websocket, DB_FTSEARCHER_NAME, DB_URL_SEARCHER_NAME, \
-    WORKER_NAMES, add_parent, send_to_worker, TWITTER_URL_SEARCHER_NAME
+    WORKER_NAMES, add_parent, send_to_worker, TWITTER_URL_SEARCHER_NAME, search_cancelled
 from common import statusUpdate
 from common.textUtils import remove_diacritics, remove_stopwords
 from database.models import ImportedArticle, ResultArticle, TopWord
@@ -31,6 +33,7 @@ def get_or_create(result_article, domain, similarity):
         return result
 
 
+@transaction.atomic
 def save_or_skip(result_article, main_search, parent):
     result_content = result_article.content
 
@@ -96,27 +99,47 @@ class FTSearcher(SyncConsumer):
     def save_or_skip(self, result_article, main_search, parent, where):
         if result_article.link == main_search.link:
             return
-        result = save_or_skip(result_article, main_search, parent)
-        if result and where not in WORKER_NAMES:
-            send_to_websocket(self.channel_layer, where=where, method='success', message='')
-            if result.link != main_search.link:
-                statusUpdate.get(TWITTER_URL_SEARCHER_NAME).queued()
-                send_to_worker(self.channel_layer, sender=self.name, where=TWITTER_URL_SEARCHER_NAME,
-                               method='search', body={
-                        'link': result.link,
-                        'search_id': main_search.id,
-                        'parent': Parent(id=result.link, type=self.name).to_dict()
-                    })
+        try:
+            result = save_or_skip(result_article, main_search, parent)
+            if result and where not in WORKER_NAMES:
+                send_to_websocket(self.channel_layer, where=where, method='success', message='')
+                if result.link != main_search.link and main_search.twitter_search:
+                    statusUpdate.get(TWITTER_URL_SEARCHER_NAME).queued(main_search.id)
+                    send_to_worker(self.channel_layer, sender=self.name, where=TWITTER_URL_SEARCHER_NAME,
+                                   method='search', body={
+                            'link': result.link,
+                            'search_id': main_search.id,
+                            'parent': Parent(id=result.link, type=self.name).to_dict()
+                        })
+        except Exception as e:
+            self.log(logging.WARNING, 'Object was not added to database: {}'.format(str(e)))
+
+    def search_parameters_correct(self, msg):
+        if not msg['body']['title']:
+            self.log(logging.INFO, 'Title cannot be empty')
+            return False
+        return True
 
     def search(self, msg):
         self.log(logging.INFO, 'Starting')
         asyncio.set_event_loop(asyncio.new_event_loop())
 
+        main_search_id = msg['body']['search_id']
         updater = statusUpdate.get(self.name)
-        updater.in_progress()
+        updater.in_progress(main_search_id)
+
+        if search_cancelled(main_search_id):
+            self.log(logging.INFO, 'Search cancelled, finishing')
+            updater.success(main_search_id)
+            return
+
+        if not self.search_parameters_correct(msg):
+            self.log(logging.INFO, 'Parameters incorrect, finishing')
+            updater.success(main_search_id)
+            return
 
         try:
-            main_search = get_main_search(msg['body']['search_id'])
+            main_search = get_main_search(main_search_id)
             title = msg['body']['title']
             parent = Parent.from_dict(msg['body']['parent'])
             sender = msg['sender']
@@ -127,12 +150,13 @@ class FTSearcher(SyncConsumer):
             for result_article in result:
                 self.save_or_skip(result_article, main_search, parent, sender)
 
-            updater.success()
+            updater.success(main_search_id)
 
             self.log(logging.INFO, 'Finished')
 
         except Exception as e:
-            updater.failure()
+            print(traceback.format_exc())
+            updater.failure(main_search_id)
             self.log(logging.WARNING, 'Failed: {0}'.format(str(e)))
 
 
@@ -146,19 +170,39 @@ class UrlSearcher(SyncConsumer):
         logging.log(level, '[{0}] {1}'.format(self.name, message))
 
     def save_or_skip(self, result_article, main_search, parent, where):
-        result = save_or_skip(result_article, main_search, parent)
-        if result and where not in WORKER_NAMES:
-            send_to_websocket(self.channel_layer, where=where, method='success', message='')
+        try:
+            result = save_or_skip(result_article, main_search, parent)
+            if result and where not in WORKER_NAMES:
+                send_to_websocket(self.channel_layer, where=where, method='success', message='')
+        except Exception as e:
+            self.log(logging.WARNING, 'Object was not added to database: {}'.format(str(e)))
+
+    def search_parameters_correct(self, msg):
+        if not msg['body']['link']:
+            self.log(logging.INFO, 'Link cannot be empty')
+            return False
+        return True
 
     def search(self, msg):
         self.log(logging.INFO, 'Starting')
         asyncio.set_event_loop(asyncio.new_event_loop())
 
+        main_search_id = msg['body']['search_id']
         updater = statusUpdate.get(self.name)
-        updater.in_progress()
+        updater.in_progress(main_search_id)
+
+        if search_cancelled(main_search_id):
+            self.log(logging.INFO, 'Search cancelled, finishing')
+            updater.success(main_search_id)
+            return
+
+        if not self.search_parameters_correct(msg):
+            self.log(logging.INFO, 'Parameters incorrect, finishing')
+            updater.success(main_search_id)
+            return
 
         try:
-            main_search = get_main_search(msg['body']['search_id'])
+            main_search = get_main_search(main_search_id)
             link = msg['body']['link']
             parent = Parent.from_dict(msg['body']['parent'])
             sender = msg['sender']
@@ -166,9 +210,10 @@ class UrlSearcher(SyncConsumer):
             result_article = ImportedArticle.objects.get(pk=link)
             self.save_or_skip(result_article, main_search, parent, sender)
 
-            updater.success()
+            updater.success(main_search_id)
             self.log(logging.INFO, 'Finished')
 
         except Exception as e:
-            updater.failure()
+            print(traceback.format_exc())
+            updater.failure(main_search_id)
             self.log(logging.WARNING, 'Failed: {0}'.format(str(e)))

--- a/googleCrawlerOfficial/googleSearcher.py
+++ b/googleCrawlerOfficial/googleSearcher.py
@@ -1,12 +1,14 @@
 import asyncio
 import json
 import logging
+import traceback
 from urllib import request
 from urllib.parse import quote
 
 from channels.consumer import SyncConsumer
 
-from common.searcherUtils import get_main_search, send_to_worker, GOOGLE_SEARCHER_NAME, INTERNET_SEARCH_MANAGER_NAME
+from common.searcherUtils import get_main_search, send_to_worker, GOOGLE_SEARCHER_NAME, INTERNET_SEARCH_MANAGER_NAME, \
+    search_cancelled
 from common import statusUpdate
 from common.url import clean_url
 from googleCrawlerOfficial import patterns
@@ -32,15 +34,32 @@ class Searcher(SyncConsumer):
     def log(self, level, message):
         logging.log(level, '[{0}] {1}'.format(self.name, message))
 
+    def search_parameters_correct(self, msg):
+        if not msg['body']['title']:
+            self.log(logging.INFO, 'Title cannot be empty')
+            return False
+        return True
+
     def search(self, msg):
         self.log(logging.INFO, 'Starting')
         asyncio.set_event_loop(asyncio.new_event_loop())
 
+        main_search_id = msg['body']['search_id']
         updater = statusUpdate.get(self.name)
-        updater.in_progress()
+        updater.in_progress(main_search_id)
+
+        if search_cancelled(main_search_id):
+            self.log(logging.INFO, 'Search cancelled, finishing')
+            updater.success(main_search_id)
+            return
+
+        if not self.search_parameters_correct(msg):
+            self.log(logging.INFO, 'Parameters incorrect, finishing')
+            updater.success(main_search_id)
+            return
 
         try:
-            main_search = get_main_search(msg['body']['search_id'])
+            main_search = get_main_search(main_search_id)
             title = msg['body']['title']
             link = msg['body']['link']
             parent = Parent.from_dict(msg['body']['parent'])
@@ -54,7 +73,7 @@ class Searcher(SyncConsumer):
                 if item['link'] == link:
                     continue
                 # send to InternetSearchManager
-                statusUpdate.get(INTERNET_SEARCH_MANAGER_NAME).queued()
+                statusUpdate.get(INTERNET_SEARCH_MANAGER_NAME).queued(main_search_id)
                 send_to_worker(self.channel_layer, sender=sender, where=INTERNET_SEARCH_MANAGER_NAME,
                                method='process_link', body={
                         'link': clean_url(item['link']),
@@ -63,9 +82,10 @@ class Searcher(SyncConsumer):
                         'search_id': main_search.id,
                     })
 
-            updater.success()
+            updater.success(main_search_id)
             self.log(logging.INFO, 'Finished')
 
         except Exception as e:
-            updater.failure()
+            print(traceback.format_exc())
+            updater.failure(main_search_id)
             self.log(logging.WARNING, 'Failed: {0}'.format(str(e)))

--- a/search/websocketConsumer.py
+++ b/search/websocketConsumer.py
@@ -72,12 +72,10 @@ class WSConsumer(WebsocketConsumer):
             self.send('done')
         self.jobs = 0
 
-    #def failure(self, signal):
-    #    logging.warning('Failure: {0}'.format(signal['message']))
 
     def send_search_request(self, where, text_data_json, search_parameters_id, search_type='search'):
         logging.info('Sending request to {0} component'.format(where))
-        statusUpdate.get(where).queued()
+        statusUpdate.get(where).queued(search_parameters_id)
         send_to_worker(self.channel_layer, sender=self.id, where=where, method=search_type, body={
             'link': clean_url(text_data_json['url']),
             'title': text_data_json['title'],


### PR DESCRIPTION
If new search is started then all workers' jobs that have been submited but not started yet should end immediately after start. Jobs that are in progress should be finished, but no objects should be added to database

This pull request contains also some refactoring including:
- tweets from twint are collected in memory, not in file,
- worker sends message to second worker only if user declared that this worker should participate in search process 